### PR TITLE
Check open PRs before closing issues

### DIFF
--- a/src/closer.py
+++ b/src/closer.py
@@ -3,6 +3,8 @@
 import re
 import logging
 
+from github import GithubException
+
 logger = logging.getLogger(__name__)
 
 CLOSE_PATTERNS = re.compile(
@@ -12,23 +14,38 @@ CLOSE_PATTERNS = re.compile(
 
 
 def extract_issue_numbers(commit_message):
-    
     matches = CLOSE_PATTERNS.findall(commit_message)
     return [int(n) for n in matches]
 
 
+def find_open_pr_for_issue(repo, issue_number):
+    """Returns the first open PR that references the given issue number, or None."""
+    keyword = f"#{issue_number}"
+    for pr in repo.get_pulls(state="open"):
+        body = pr.body or ""
+        if keyword in (pr.title + " " + body):
+            return pr
+    return None
+
+
 def close_issues_from_push(repo, commits):
- 
- 
-    print("  [closer] Checking commits for 'closes #N'...")
+    logger.info("Checking commits for 'closes #N'... (%d commit(s) received)", len(commits))
     closed_count = 0
+    already_processed = set()
 
     for commit_data in commits:
         message = commit_data.get("message", "")
         sha = commit_data.get("id", "")[:7]
+        author = commit_data.get("author", {}).get("name", "unknown")
         issue_numbers = extract_issue_numbers(message)
 
         for number in issue_numbers:
+            if number in already_processed:
+                logger.debug("Issue #%s: already processed in this push, skipping.", number)
+                continue
+
+            already_processed.add(number)
+
             try:
                 issue = repo.get_issue(number)
 
@@ -36,17 +53,31 @@ def close_issues_from_push(repo, commits):
                     logger.debug("Issue #%s: already closed, skipping.", number)
                     continue
 
+                open_pr = find_open_pr_for_issue(repo, number)
+                if open_pr:
+                    issue.create_comment(
+                        f"⚠️ Commit [`{sha}`](https://github.com/{repo.full_name}/commit/{commit_data.get('id', '')}) "
+                        f"references this issue, but Pull Request #{open_pr.number} is still open. "
+                        f"This issue will not be closed automatically until the PR is merged."
+                    )
+                    logger.info("Issue #%s: skipped close, open PR #%s found.", number, open_pr.number)
+                    continue
+
                 comment = (
                     f"This issue was automatically closed by commit "
-                    f"[`{sha}`](https://github.com/{repo.full_name}/commit/{commit_data.get('id', '')})"
-                    f".\n\n> {message}"
+                    f"[`{sha}`](https://github.com/{repo.full_name}/commit/{commit_data.get('id', '')}) "
+                    f"by **{author}**."
+                    f"\n\n> {message}"
                 )
                 issue.create_comment(comment)
                 issue.edit(state="closed")
-                logger.info("Issue #%s: closed by commit %s.", number, sha)
+                logger.info("Issue #%s: closed by commit %s (author: %s).", number, sha, author)
                 closed_count += 1
 
-            except Exception as e:
-                logger.error("Failed to close issue #%s: %s", number, e)
+            except GithubException as e:
+                if e.status == 404:
+                    logger.warning("Issue #%s not found in repo, skipping.", number)
+                else:
+                    logger.error("Failed to close issue #%s: %s", number, e)
 
     logger.info("Closer done. Issues closed: %d.", closed_count)


### PR DESCRIPTION
## Что сделано

- Добавлена проверка открытых pull request перед автоматическим закрытием issue по commit message.
- Если commit ссылается на issue, но по нему ещё открыт PR, issue больше не закрывается автоматически.
- В таком случае в issue добавляется предупреждающий комментарий.
- Добавлена дедупликация: одно и то же issue обрабатывается только один раз за push.
- Улучшено логирование и обработка отсутствующих issue через `GithubException`.

## Проверка

- `python3 -m compileall src tests` — успешно
- `python3 -m pytest` — успешно, 22 теста passed
